### PR TITLE
Add cron trigger

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  schedule:
+    # Runs at 8am UTC Mon-Fri
+    - cron: '0 8 * * 1-5'
 env:
   PASSWORD: ${{ secrets.PASSWORD }}
 jobs:


### PR DESCRIPTION
Add cron trigger to Playwright workflow such that full test suite will now run on:

- PR to `main` (chromium only)
- push to `main` (inc. merging PRs)
- manual trigger
- scheduled trigger at 8am UTC Mon to Fri