### PR TITLE
Update product page tests

### DIFF
--- a/pages/productPage.ts
+++ b/pages/productPage.ts
@@ -1,5 +1,4 @@
 import { expect, Locator, Page } from '@playwright/test';
-import { COLORS, EXPECTED_TEXT } from './inventoryPage';
 import { PageFooter } from './components/pageFooter';
 import { PageHeader } from './components/pageHeader';
 
@@ -46,3 +45,18 @@ export class ProductPage {
     await expect(this.cartButton).toHaveCSS('color', BUTTON_COLOR);
   }
 }
+
+export const EXPECTED_TEXT = {
+  addToCartButton: 'Add to cart',
+  removeButton: 'Remove',
+};
+
+export const COLORS = {
+  backgroundColor: 'rgb(255, 255, 255)',
+  textColor: 'rgb(19, 35, 34)',
+  backButtonHoverColor: 'rgb(61, 220, 145)',
+  productBorderColor: 'rgb(237, 237, 237)',
+  productTitleColor: 'rgb(24, 88, 58)',
+  addButtonColor: 'rgb(19, 35, 34)',
+  removeButtonColor: 'rgb(226, 35, 26)',
+};

--- a/tests/productPage.spec.ts
+++ b/tests/productPage.spec.ts
@@ -60,6 +60,11 @@ test.describe('Product page tests', () => {
         await expect(productPage.cartButton).toHaveCSS('width', '160px');
       });
 
+      test('Back button style updates on hover', async () => {
+        await productPage.backButton.hover();
+        await expect(productPage.backButton).toHaveCSS('color', COLORS.backButtonHoverColor);
+      });
+
       test.describe('Add to cart & remove', () => {
         // Which products are in the cart is tracked via a cart-contents array in local storage.
         // As each product can only be added to the cart once it uses an array of product IDs.

--- a/tests/productPage.spec.ts
+++ b/tests/productPage.spec.ts
@@ -1,7 +1,7 @@
 import test, { BrowserContext, expect } from '@playwright/test';
-import { ProductPage } from '../pages/productPage';
+import { COLORS, EXPECTED_TEXT, ProductPage } from '../pages/productPage';
 import { LoginPage } from '../pages/loginPage';
-import { COLORS, EXPECTED_TEXT, InventoryPage, PRODUCT_INFO } from '../pages/inventoryPage';
+import { InventoryPage, PRODUCT_INFO } from '../pages/inventoryPage';
 
 test.describe('Product page tests', () => {
   let productPage: ProductPage;


### PR DESCRIPTION
Minor updates to the product page tests including:

- verifying the back button style on hover
- adding color & expected text consts to product page POM & using them in the tests rather than importing from inventory page
  - This breaks a dependency between the pages, which shouldn't really have been there in the first place but because there is commonality I originally decided not to duplicate the consts into the product page POM but given the pages are independent they should each have their own consts even if there is overlap between them