### PR TITLE
Move product data to separate module

### DIFF
--- a/data/products.ts
+++ b/data/products.ts
@@ -1,0 +1,56 @@
+export const PRODUCT_INFO = [
+  {
+    id: 4,
+    title: 'Sauce Labs Backpack',
+    imgSrc: '/static/media/sauce-backpack-1200x1500.0a0b85a385945026062b.jpg',
+    description:
+      'carry.allTheThings() with the sleek, streamlined Sly Pack that melds uncompromising style with unequaled laptop and tablet protection.',
+    price: 29.99,
+    shortName: 'Backpack',
+  },
+  {
+    id: 0,
+    title: 'Sauce Labs Bike Light',
+    imgSrc: '/static/media/bike-light-1200x1500.37c843b09a7d77409d63.jpg',
+    description:
+      "A red light isn't the desired state in testing but it sure helps when riding your bike at night. Water-resistant with 3 lighting modes, 1 AAA battery included.",
+    price: 9.99,
+    shortName: 'Bike Light',
+  },
+  {
+    id: 1,
+    title: 'Sauce Labs Bolt T-Shirt',
+    imgSrc: '/static/media/bolt-shirt-1200x1500.c2599ac5f0a35ed5931e.jpg',
+    description:
+      'Get your testing superhero on with the Sauce Labs bolt T-shirt. From American Apparel, 100% ringspun combed cotton, heather gray with red bolt.',
+    price: 15.99,
+    shortName: 'Bolt T-Shirt',
+  },
+  {
+    id: 5,
+    title: 'Sauce Labs Fleece Jacket',
+    imgSrc: '/static/media/sauce-pullover-1200x1500.51d7ffaf301e698772c8.jpg',
+    description:
+      "It's not every day that you come across a midweight quarter-zip fleece jacket capable of handling everything from a relaxing day outdoors to a busy day at the office.",
+    price: 49.99,
+    shortName: 'Fleece Jacket',
+  },
+  {
+    id: 2,
+    title: 'Sauce Labs Onesie',
+    imgSrc: '/static/media/red-onesie-1200x1500.2ec615b271ef4c3bc430.jpg',
+    description:
+      "Rib snap infant onesie for the junior automation engineer in development. Reinforced 3-snap bottom closure, two-needle hemmed sleeved and bottom won't unravel.",
+    price: 7.99,
+    shortName: 'Onesie',
+  },
+  {
+    id: 3,
+    title: 'Test.allTheThings() T-Shirt (Red)',
+    imgSrc: '/static/media/red-tatt-1200x1500.30dadef477804e54fc7b.jpg',
+    description:
+      'This classic Sauce Labs t-shirt is perfect to wear when cozying up to your keyboard to automate a few tests. Super-soft and comfy ringspun combed cotton.',
+    price: 15.99,
+    shortName: 'Red T-Shirt',
+  },
+];

--- a/pages/inventoryPage.ts
+++ b/pages/inventoryPage.ts
@@ -1,6 +1,7 @@
 import { expect, Locator, Page } from '@playwright/test';
 import { PageFooter } from './components/pageFooter';
 import { PageHeader } from './components/pageHeader';
+import { PRODUCT_INFO } from '../data/products';
 
 export class InventoryPage {
   readonly url = '/inventory.html';
@@ -75,63 +76,6 @@ export const COLORS = {
   addButtonColor: 'rgb(19, 35, 34)',
   removeButtonColor: 'rgb(226, 35, 26)',
 };
-
-export const PRODUCT_INFO = [
-  {
-    id: 4,
-    title: 'Sauce Labs Backpack',
-    imgSrc: '/static/media/sauce-backpack-1200x1500.0a0b85a385945026062b.jpg',
-    description:
-      'carry.allTheThings() with the sleek, streamlined Sly Pack that melds uncompromising style with unequaled laptop and tablet protection.',
-    price: 29.99,
-    shortName: 'Backpack',
-  },
-  {
-    id: 0,
-    title: 'Sauce Labs Bike Light',
-    imgSrc: '/static/media/bike-light-1200x1500.37c843b09a7d77409d63.jpg',
-    description:
-      "A red light isn't the desired state in testing but it sure helps when riding your bike at night. Water-resistant with 3 lighting modes, 1 AAA battery included.",
-    price: 9.99,
-    shortName: 'Bike Light',
-  },
-  {
-    id: 1,
-    title: 'Sauce Labs Bolt T-Shirt',
-    imgSrc: '/static/media/bolt-shirt-1200x1500.c2599ac5f0a35ed5931e.jpg',
-    description:
-      'Get your testing superhero on with the Sauce Labs bolt T-shirt. From American Apparel, 100% ringspun combed cotton, heather gray with red bolt.',
-    price: 15.99,
-    shortName: 'Bolt T-Shirt',
-  },
-  {
-    id: 5,
-    title: 'Sauce Labs Fleece Jacket',
-    imgSrc: '/static/media/sauce-pullover-1200x1500.51d7ffaf301e698772c8.jpg',
-    description:
-      "It's not every day that you come across a midweight quarter-zip fleece jacket capable of handling everything from a relaxing day outdoors to a busy day at the office.",
-    price: 49.99,
-    shortName: 'Fleece Jacket',
-  },
-  {
-    id: 2,
-    title: 'Sauce Labs Onesie',
-    imgSrc: '/static/media/red-onesie-1200x1500.2ec615b271ef4c3bc430.jpg',
-    description:
-      "Rib snap infant onesie for the junior automation engineer in development. Reinforced 3-snap bottom closure, two-needle hemmed sleeved and bottom won't unravel.",
-    price: 7.99,
-    shortName: 'Onesie',
-  },
-  {
-    id: 3,
-    title: 'Test.allTheThings() T-Shirt (Red)',
-    imgSrc: '/static/media/red-tatt-1200x1500.30dadef477804e54fc7b.jpg',
-    description:
-      'This classic Sauce Labs t-shirt is perfect to wear when cozying up to your keyboard to automate a few tests. Super-soft and comfy ringspun combed cotton.',
-    price: 15.99,
-    shortName: 'Red T-Shirt',
-  },
-];
 
 export enum PRODUCT_ELEMENTS {
   img = 'img.inventory_item_img',

--- a/tests/inventoryPage.spec.ts
+++ b/tests/inventoryPage.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, BrowserContext } from '@playwright/test';
-import { COLORS, EXPECTED_TEXT, InventoryPage, PRODUCT_ELEMENTS, PRODUCT_INFO } from '../pages/inventoryPage';
+import { COLORS, EXPECTED_TEXT, InventoryPage, PRODUCT_ELEMENTS } from '../pages/inventoryPage';
 import { LoginPage } from '../pages/loginPage';
+import { PRODUCT_INFO } from '../data/products';
 
 test.describe('Inventory page tests', () => {
   let inventoryPage: InventoryPage;

--- a/tests/menu.spec.ts
+++ b/tests/menu.spec.ts
@@ -1,9 +1,10 @@
 import test, { expect } from '@playwright/test';
 import { LoginPage } from '../pages/loginPage';
-import { InventoryPage, PRODUCT_ELEMENTS, PRODUCT_INFO } from '../pages/inventoryPage';
+import { InventoryPage, PRODUCT_ELEMENTS } from '../pages/inventoryPage';
 import { COLORS, EXPECTED_TEXT, LINKS, Menu } from '../pages/components/menu';
 import { PageHeader } from '../pages/components/pageHeader';
 import { ProductPage } from '../pages/productPage';
+import { PRODUCT_INFO } from '../data/products';
 
 // This spec makes a not unreasonable assumption that the menu is the same across all pages.
 // As such, the main assertions are performed against a single page (the inventory page).

--- a/tests/pageFooter.spec.ts
+++ b/tests/pageFooter.spec.ts
@@ -1,7 +1,8 @@
 import test, { expect } from '@playwright/test';
 import { COLORS, EXPECTED_TEXT, PageFooter, SOCIAL_LINKS } from '../pages/components/pageFooter';
 import { LoginPage } from '../pages/loginPage';
-import { InventoryPage, PRODUCT_ELEMENTS, PRODUCT_INFO } from '../pages/inventoryPage';
+import { InventoryPage, PRODUCT_ELEMENTS } from '../pages/inventoryPage';
+import { PRODUCT_INFO } from '../data/products';
 
 // This spec makes a not unreasonable assumption that the footer displayed at the bottom of all pages
 // expect the login page is always the same. As such, the main assertions are performed against a single

--- a/tests/pageHeader.spec.ts
+++ b/tests/pageHeader.spec.ts
@@ -1,7 +1,8 @@
 import test, { expect } from '@playwright/test';
 import { COLORS, EXPECTED_TEXT, PageHeader } from '../pages/components/pageHeader';
-import { InventoryPage, PRODUCT_INFO } from '../pages/inventoryPage';
+import { InventoryPage } from '../pages/inventoryPage';
 import { LoginPage } from '../pages/loginPage';
+import { PRODUCT_INFO } from '../data/products';
 
 // This spec makes a not unreasonable assumption that the header displayed at the top of all pages
 // expect the login page is mostly the same across all pages. As such, the main assertions are performed

--- a/tests/productPage.spec.ts
+++ b/tests/productPage.spec.ts
@@ -1,7 +1,8 @@
 import test, { BrowserContext, expect } from '@playwright/test';
 import { COLORS, EXPECTED_TEXT, ProductPage } from '../pages/productPage';
 import { LoginPage } from '../pages/loginPage';
-import { InventoryPage, PRODUCT_INFO } from '../pages/inventoryPage';
+import { InventoryPage } from '../pages/inventoryPage';
+import { PRODUCT_INFO } from '../data/products';
 
 test.describe('Product page tests', () => {
   let productPage: ProductPage;


### PR DESCRIPTION
The details of the products offered in the store under test are the same across all pages so don't really belong in a single POM class as they aren't really owned by any particular page. As such it makes sense to move them to a separate module in a new `data` folder at the top level and for that module to be imported wherever we utilise the product info currently.

Other const data such as the expected text and colors could potentially vary between pages so they should be declared in the individual POMs as they are currently; only the product data is explicitly shared so should be declared globally.