### PR TITLE
Add helper functions

### DIFF
--- a/helpers/utils.ts
+++ b/helpers/utils.ts
@@ -1,0 +1,25 @@
+import { BrowserContext, expect, Locator, Page } from '@playwright/test';
+
+export const getCartContentsFromLocalStorage = async (context: BrowserContext) => {
+  const storageState = await context.storageState();
+  return storageState.origins![0].localStorage.filter((item) => item.name === 'cart-contents')[0];
+};
+
+export const setCartContentsInLocalStorage = async (page: Page, productIds: number[], url: string) => {
+  await page.evaluate((productIds) => localStorage.setItem('cart-contents', `[${productIds.join()}]`), productIds);
+  // Reopen the page to pick up the local storage change
+  // NB page.reload() doesn't seem to work on webkit browsers on Linux so use .goto()
+  await page.goto(url);
+};
+
+export const verifyCartButtonStyle = async (
+  button: Locator,
+  buttonText: string,
+  buttonColor: string,
+  buttonClass: string
+): Promise<void> => {
+  await expect(button).toHaveText(buttonText);
+  await expect(button).toContainClass(buttonClass);
+  await expect(button).toHaveCSS('border', `1px solid ${buttonColor}`);
+  await expect(button).toHaveCSS('color', buttonColor);
+};

--- a/pages/inventoryPage.ts
+++ b/pages/inventoryPage.ts
@@ -1,7 +1,8 @@
-import { expect, Locator, Page } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 import { PageFooter } from './components/pageFooter';
 import { PageHeader } from './components/pageHeader';
 import { PRODUCT_INFO } from '../data/products';
+import { verifyCartButtonStyle } from '../helpers/utils';
 
 export class InventoryPage {
   readonly url = '/inventory.html';
@@ -49,14 +50,12 @@ export class InventoryPage {
     const BUTTON_TEXT = style === 'add' ? EXPECTED_TEXT.addToCartButton : EXPECTED_TEXT.removeButton;
     const BUTTON_COLOR = style === 'add' ? COLORS.addButtonColor : COLORS.removeButtonColor;
     const BUTTON_CLASS = style === 'add' ? 'btn_primary' : 'btn_secondary';
-    await expect(this.getProductElement(productIndex, PRODUCT_ELEMENTS.button)).toHaveText(BUTTON_TEXT);
-    // await expect(this.getProductElement(productIndex, PRODUCT_ELEMENTS.button)).not.toContainClass('btn_primary');
-    await expect(this.getProductElement(productIndex, PRODUCT_ELEMENTS.button)).toContainClass(BUTTON_CLASS);
-    await expect(this.getProductElement(productIndex, PRODUCT_ELEMENTS.button)).toHaveCSS(
-      'border',
-      `1px solid ${BUTTON_COLOR}`
+    await verifyCartButtonStyle(
+      this.getProductElement(productIndex, PRODUCT_ELEMENTS.button),
+      BUTTON_TEXT,
+      BUTTON_COLOR,
+      BUTTON_CLASS
     );
-    await expect(this.getProductElement(productIndex, PRODUCT_ELEMENTS.button)).toHaveCSS('color', BUTTON_COLOR);
   }
 }
 

--- a/pages/productPage.ts
+++ b/pages/productPage.ts
@@ -1,6 +1,7 @@
-import { expect, Locator, Page } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 import { PageFooter } from './components/pageFooter';
 import { PageHeader } from './components/pageHeader';
+import { verifyCartButtonStyle } from '../helpers/utils';
 
 export class ProductPage {
   readonly url = '/inventory-item.html?id=';
@@ -39,10 +40,7 @@ export class ProductPage {
     const BUTTON_TEXT = style === 'add' ? EXPECTED_TEXT.addToCartButton : EXPECTED_TEXT.removeButton;
     const BUTTON_COLOR = style === 'add' ? COLORS.addButtonColor : COLORS.removeButtonColor;
     const BUTTON_CLASS = style === 'add' ? 'btn_primary' : 'btn_secondary';
-    await expect(this.cartButton).toHaveText(BUTTON_TEXT);
-    await expect(this.cartButton).toContainClass(BUTTON_CLASS);
-    await expect(this.cartButton).toHaveCSS('border', `1px solid ${BUTTON_COLOR}`);
-    await expect(this.cartButton).toHaveCSS('color', BUTTON_COLOR);
+    await verifyCartButtonStyle(this.cartButton, BUTTON_TEXT, BUTTON_COLOR, BUTTON_CLASS);
   }
 }
 

--- a/tests/inventoryPage.spec.ts
+++ b/tests/inventoryPage.spec.ts
@@ -1,7 +1,8 @@
-import { test, expect, BrowserContext } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import { COLORS, EXPECTED_TEXT, InventoryPage, PRODUCT_ELEMENTS } from '../pages/inventoryPage';
 import { LoginPage } from '../pages/loginPage';
 import { PRODUCT_INFO } from '../data/products';
+import { getCartContentsFromLocalStorage } from '../helpers/utils';
 
 test.describe('Inventory page tests', () => {
   let inventoryPage: InventoryPage;
@@ -159,7 +160,7 @@ test.describe('Inventory page tests', () => {
       // the header, as tested in the page header spec. So all we need to test here is that
       // product IDs are added to the cart-contents array in local storage correctly
 
-      let cartContents: Record<string, string | string[]>;
+      let cartContents: Record<string, string>;
       let productIDs: string;
 
       test('Add product to cart', async ({ context }) => {
@@ -275,8 +276,3 @@ test.describe('Inventory page tests', () => {
     }
   });
 });
-
-const getCartContentsFromLocalStorage = async (context: BrowserContext) => {
-  const storageState = await context.storageState();
-  return storageState.origins![0].localStorage.filter((item) => item.name === 'cart-contents')[0];
-};

--- a/tests/menu.spec.ts
+++ b/tests/menu.spec.ts
@@ -5,6 +5,7 @@ import { COLORS, EXPECTED_TEXT, LINKS, Menu } from '../pages/components/menu';
 import { PageHeader } from '../pages/components/pageHeader';
 import { ProductPage } from '../pages/productPage';
 import { PRODUCT_INFO } from '../data/products';
+import { setCartContentsInLocalStorage } from '../helpers/utils';
 
 // This spec makes a not unreasonable assumption that the menu is the same across all pages.
 // As such, the main assertions are performed against a single page (the inventory page).
@@ -143,12 +144,7 @@ test.describe('Menu tests', () => {
     }) => {
       // "Force" products into cart via local storage
       const productsInCart = [0, 1];
-      await page.evaluate(
-        (productsInCart) => localStorage.setItem('cart-contents', `[${productsInCart.join()}]`),
-        productsInCart
-      );
-      // Reopen the page to pick up the local storage change
-      await page.goto(inventoryPage.url);
+      await setCartContentsInLocalStorage(page, productsInCart, inventoryPage.url);
       await expect(pageHeader.shoppingCartBadge).toBeVisible();
       await expect(pageHeader.shoppingCartBadge).toHaveText(`${productsInCart.length}`);
       for (let i = 0; i < PRODUCT_INFO.length; i++) {

--- a/tests/pageHeader.spec.ts
+++ b/tests/pageHeader.spec.ts
@@ -3,6 +3,7 @@ import { COLORS, EXPECTED_TEXT, PageHeader } from '../pages/components/pageHeade
 import { InventoryPage } from '../pages/inventoryPage';
 import { LoginPage } from '../pages/loginPage';
 import { PRODUCT_INFO } from '../data/products';
+import { setCartContentsInLocalStorage } from '../helpers/utils';
 
 // This spec makes a not unreasonable assumption that the header displayed at the top of all pages
 // expect the login page is mostly the same across all pages. As such, the main assertions are performed
@@ -66,13 +67,7 @@ test.describe('Page header tests', () => {
       let productIds: number[] = [];
       for (let i = 0; i < PRODUCT_INFO.length; i++) {
         productIds.push(i);
-        await page.evaluate(
-          (productIds) => localStorage.setItem('cart-contents', `[${productIds.join()}]`),
-          productIds
-        );
-        // Reopen the page to pick up the local storage change
-        // NB page.reload() doesn't seem to work on webkit browsers on Linux so use .goto()
-        await page.goto(inventoryPage.url);
+        await setCartContentsInLocalStorage(page, productIds, inventoryPage.url);
         await expect(pageHeader.shoppingCartBadge).toBeVisible();
         await expect(pageHeader.shoppingCartBadge).toHaveText(`${i + 1}`);
       }
@@ -87,10 +82,7 @@ test.describe('Page header tests', () => {
       });
 
       test('Products in cart', async ({ page }) => {
-        await page.evaluate(() => localStorage.setItem('cart-contents', '[0,1]'));
-        // Reopen the page to pick up the local storage change
-        // NB page.reload() doesn't seem to work on webkit browsers on Linux so use .goto()
-        await page.goto(inventoryPage.url);
+        await setCartContentsInLocalStorage(page, [0, 1], inventoryPage.url);
         await expect(pageHeader.primaryHeader).toHaveScreenshot('productsInCart.png');
       });
     });

--- a/tests/productPage.spec.ts
+++ b/tests/productPage.spec.ts
@@ -1,8 +1,9 @@
-import test, { BrowserContext, expect } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import { COLORS, EXPECTED_TEXT, ProductPage } from '../pages/productPage';
 import { LoginPage } from '../pages/loginPage';
 import { InventoryPage } from '../pages/inventoryPage';
 import { PRODUCT_INFO } from '../data/products';
+import { getCartContentsFromLocalStorage } from '../helpers/utils';
 
 test.describe('Product page tests', () => {
   let productPage: ProductPage;
@@ -72,7 +73,7 @@ test.describe('Product page tests', () => {
         // The length of this array is used to determine the badge to display over the cart in
         // the header, as tested in the page header spec. So all we need to test here is that
         // product IDs are added to the cart-contents array in local storage correctly
-        let cartContents: Record<string, string | string[]>;
+        let cartContents: Record<string, string>;
 
         test('Add product to cart', async ({ context }) => {
           await productPage.cartButton.click();
@@ -169,9 +170,4 @@ const generateProductSnapshotName = (name: string): string => {
   // Sanitise product name for use as snapshot name
   // Remove spaces & dashes then convert first letter to lowercase
   return name.charAt(0).toLowerCase() + name.slice(1).replace(' ', '').replace('-', '') + '.png';
-};
-
-const getCartContentsFromLocalStorage = async (context: BrowserContext) => {
-  const storageState = await context.storageState();
-  return storageState.origins![0].localStorage.filter((item) => item.name === 'cart-contents')[0];
 };


### PR DESCRIPTION
Introduce a new `helpers\utils.ts` module containing some helper/utility functions that are useful throughout the test framework. This includes:
- getting `cart-contents` from local storage
- setting `cart-contents` in local storage (to allow products to be "forced" into the shopping cart)
- verify cart button style (was previously declared in both the `ProductPage` and `InventoryPage` POMs with slightly different element selectors; this util function contains the common assertions to reduce duplication)
- updating the imports where necessary

There is also a small change to correct the type definition of `cartContents` where used in the test specs