### PR TITLE
More util functions

### DIFF
--- a/helpers/utils.ts
+++ b/helpers/utils.ts
@@ -11,12 +11,12 @@ export const login = async (page: Page, baseURL: string, username: string): Prom
   await expect(page).toHaveURL(`${baseURL}${URLS.inventoryPage}`);
 };
 
-export const getCartContentsFromLocalStorage = async (context: BrowserContext) => {
+export const getCartContentsFromLocalStorage = async (context: BrowserContext): Promise<Record<string, string>> => {
   const storageState = await context.storageState();
   return storageState.origins![0].localStorage.filter((item) => item.name === 'cart-contents')[0];
 };
 
-export const setCartContentsInLocalStorage = async (page: Page, productIds: number[], url: string) => {
+export const setCartContentsInLocalStorage = async (page: Page, productIds: number[], url: string): Promise<void> => {
   await page.evaluate((productIds) => localStorage.setItem('cart-contents', `[${productIds.join()}]`), productIds);
   // Reopen the page to pick up the local storage change
   // NB page.reload() doesn't seem to work on webkit browsers on Linux so use .goto()

--- a/helpers/utils.ts
+++ b/helpers/utils.ts
@@ -1,4 +1,15 @@
 import { BrowserContext, expect, Locator, Page } from '@playwright/test';
+import { LoginPage } from '../pages/loginPage';
+import { URLS } from '../data/pages';
+
+export const login = async (page: Page, baseURL: string, username: string): Promise<void> => {
+  const loginPage = new LoginPage(page);
+  await page.goto(URLS.loginPage);
+  await loginPage.usernameInput.fill(username);
+  await loginPage.passwordInput.fill('secret_sauce');
+  await loginPage.loginButton.click();
+  await expect(page).toHaveURL(`${baseURL}${URLS.inventoryPage}`);
+};
 
 export const getCartContentsFromLocalStorage = async (context: BrowserContext) => {
   const storageState = await context.storageState();

--- a/helpers/utils.ts
+++ b/helpers/utils.ts
@@ -1,4 +1,4 @@
-import { BrowserContext, expect, Locator, Page } from '@playwright/test';
+import { BrowserContext, Cookie, expect, Locator, Page } from '@playwright/test';
 import { LoginPage } from '../pages/loginPage';
 import { URLS } from '../data/pages';
 
@@ -21,6 +21,10 @@ export const setCartContentsInLocalStorage = async (page: Page, productIds: numb
   // Reopen the page to pick up the local storage change
   // NB page.reload() doesn't seem to work on webkit browsers on Linux so use .goto()
   await page.goto(url);
+};
+
+export const getCookies = async (context: BrowserContext, url: string): Promise<Cookie[]> => {
+  return await context.cookies(url);
 };
 
 export const verifyCartButtonStyle = async (

--- a/pages/loginPage.ts
+++ b/pages/loginPage.ts
@@ -1,5 +1,4 @@
 import { Locator, Page, expect } from '@playwright/test';
-import { URLS } from '../data/pages';
 
 type CredentialsInputs = 'username' | 'password';
 
@@ -36,16 +35,6 @@ export class LoginPage {
     this.password = this.credentialsContainer.getByTestId('login-password');
     this.usernamesHeader = this.usernames.locator('h4');
     this.passwordHeader = this.password.locator('h4');
-  }
-
-  // *******
-  // ACTIONS
-  // *******
-  async login(username: string) {
-    await this.page.goto(URLS.loginPage);
-    await this.usernameInput.fill(username);
-    await this.passwordInput.fill('secret_sauce');
-    await this.loginButton.click();
   }
 
   // **********

--- a/tests/inventoryPage.spec.ts
+++ b/tests/inventoryPage.spec.ts
@@ -1,18 +1,15 @@
 import { test, expect } from '@playwright/test';
 import { COLORS, EXPECTED_TEXT, InventoryPage, PRODUCT_ELEMENTS } from '../pages/inventoryPage';
-import { LoginPage } from '../pages/loginPage';
 import { PRODUCT_INFO } from '../data/products';
-import { getCartContentsFromLocalStorage } from '../helpers/utils';
+import { getCartContentsFromLocalStorage, login } from '../helpers/utils';
 import { URLS } from '../data/pages';
 
 test.describe('Inventory page tests', () => {
   let inventoryPage: InventoryPage;
 
   test.beforeEach(async ({ page, baseURL }) => {
-    let loginPage = new LoginPage(page);
     inventoryPage = new InventoryPage(page);
-    await loginPage.login('standard_user');
-    await expect(page).toHaveURL(`${baseURL}${URLS.inventoryPage}`);
+    await login(page, baseURL!, 'standard_user');
   });
 
   test.describe('Appearance tests', () => {

--- a/tests/loginPage.spec.ts
+++ b/tests/loginPage.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { LoginPage, COLORS, FONT_SIZES, EXPECTED_TEXT } from '../pages/loginPage';
 import { URLS } from '../data/pages';
+import { getCookies } from '../helpers/utils';
 
 test.describe('Login page tests', () => {
   let loginPage: LoginPage;
@@ -119,7 +120,7 @@ test.describe('Login page tests', () => {
             await loginPage.passwordInput.fill(PASSWORD);
             await loginPage.loginButton.click();
             await expect(page).toHaveURL(`${baseURL}${URLS.inventoryPage}`);
-            const cookies = await context.cookies(baseURL);
+            const cookies = await getCookies(context, baseURL!);
             expect(cookies).toHaveLength(1);
             expect(cookies[0]).toHaveProperty('name', 'session-username');
             expect(cookies[0]).toHaveProperty('value', username);

--- a/tests/menu.spec.ts
+++ b/tests/menu.spec.ts
@@ -1,25 +1,21 @@
 import { test, expect } from '@playwright/test';
-import { LoginPage } from '../pages/loginPage';
 import { InventoryPage, PRODUCT_ELEMENTS } from '../pages/inventoryPage';
 import { COLORS, EXPECTED_TEXT, LINKS, Menu } from '../pages/components/menu';
 import { PageHeader } from '../pages/components/pageHeader';
 import { PRODUCT_INFO } from '../data/products';
-import { setCartContentsInLocalStorage } from '../helpers/utils';
+import { login, setCartContentsInLocalStorage } from '../helpers/utils';
 import { URLS } from '../data/pages';
 
 // This spec makes a not unreasonable assumption that the menu is the same across all pages.
 // As such, the main assertions are performed against a single page (the inventory page).
 
 test.describe('Menu tests', () => {
-  let loginPage: LoginPage;
   let pageHeader: PageHeader;
   let menu: Menu;
   const numMenuItems = EXPECTED_TEXT.menuItems.length;
 
   test.beforeEach(async ({ page, baseURL }) => {
-    loginPage = new LoginPage(page);
-    await loginPage.login('standard_user');
-    await expect(page).toHaveURL(`${baseURL}${URLS.inventoryPage}`);
+    await login(page, baseURL!, 'standard_user');
     pageHeader = new PageHeader(page);
     menu = new Menu(page);
   });

--- a/tests/pageFooter.spec.ts
+++ b/tests/pageFooter.spec.ts
@@ -1,9 +1,8 @@
 import { test, expect } from '@playwright/test';
 import { COLORS, EXPECTED_TEXT, PageFooter, SOCIAL_LINKS } from '../pages/components/pageFooter';
-import { LoginPage } from '../pages/loginPage';
 import { InventoryPage, PRODUCT_ELEMENTS } from '../pages/inventoryPage';
 import { PRODUCT_INFO } from '../data/products';
-import { URLS } from '../data/pages';
+import { login } from '../helpers/utils';
 
 // This spec makes a not unreasonable assumption that the footer displayed at the bottom of all pages
 // expect the login page is always the same. As such, the main assertions are performed against a single
@@ -13,9 +12,7 @@ test.describe('Page footer tests', () => {
   let pageFooter: PageFooter;
 
   test.beforeEach(async ({ page, baseURL }) => {
-    const loginPage = new LoginPage(page);
-    await loginPage.login('standard_user');
-    await expect(page).toHaveURL(`${baseURL}${URLS.inventoryPage}`);
+    await login(page, baseURL!, 'standard_user');
     pageFooter = new PageFooter(page);
   });
 

--- a/tests/pageHeader.spec.ts
+++ b/tests/pageHeader.spec.ts
@@ -1,8 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { COLORS, EXPECTED_TEXT, PageHeader } from '../pages/components/pageHeader';
-import { LoginPage } from '../pages/loginPage';
 import { PRODUCT_INFO } from '../data/products';
-import { setCartContentsInLocalStorage } from '../helpers/utils';
+import { login, setCartContentsInLocalStorage } from '../helpers/utils';
 import { URLS } from '../data/pages';
 
 // This spec makes a not unreasonable assumption that the header displayed at the top of all pages
@@ -15,9 +14,7 @@ test.describe('Page header tests', () => {
   let pageHeader: PageHeader;
 
   test.beforeEach(async ({ page, baseURL }) => {
-    const loginPage = new LoginPage(page);
-    await loginPage.login('standard_user');
-    await expect(page).toHaveURL(`${baseURL}${URLS.inventoryPage}`);
+    await login(page, baseURL!, 'standard_user');
     pageHeader = new PageHeader(page);
   });
 

--- a/tests/productPage.spec.ts
+++ b/tests/productPage.spec.ts
@@ -1,17 +1,15 @@
 import { test, expect } from '@playwright/test';
 import { COLORS, EXPECTED_TEXT, ProductPage } from '../pages/productPage';
-import { LoginPage } from '../pages/loginPage';
 import { PRODUCT_INFO } from '../data/products';
-import { getCartContentsFromLocalStorage } from '../helpers/utils';
+import { getCartContentsFromLocalStorage, login } from '../helpers/utils';
 import { URLS } from '../data/pages';
 
 test.describe('Product page tests', () => {
   let productPage: ProductPage;
 
-  test.beforeEach(async ({ page }) => {
-    const loginPage = new LoginPage(page);
+  test.beforeEach(async ({ page, baseURL }) => {
     productPage = new ProductPage(page);
-    await loginPage.login('standard_user');
+    await login(page, baseURL!, 'standard_user');
   });
 
   test.describe('Common page elements', async () => {


### PR DESCRIPTION
- Move `login` from being a method on the `LoginPage` to a utll function
  - This breaks a dependency various specs had on the `LoginPage` when all they needed it for was just the `login` method
- Add `getCookies` util function & use in `loginPage.spec.ts`
  - This is currently the only place we access cookies but I have an upcoming use case for cookies that makes sense for there to be a util function for them going forwards