### PR TITLE
Add locators for individual buttons on cart page

### DIFF
--- a/pages/cartPage.ts
+++ b/pages/cartPage.ts
@@ -13,6 +13,8 @@ export class CartPage {
   readonly cartItem: Locator;
   readonly cartFooter: Locator;
   readonly actionButton: Locator;
+  readonly continueShoppingButton: Locator;
+  readonly checkoutButton: Locator;
   readonly pageFooter: PageFooter;
 
   constructor(page: Page) {
@@ -26,6 +28,8 @@ export class CartPage {
     this.cartItem = this.cartList.getByTestId('inventory-item');
     this.cartFooter = this.cartContentsContainer.locator('div.cart_footer');
     this.actionButton = this.cartFooter.locator('button');
+    this.continueShoppingButton = this.cartFooter.getByTestId('continue-shopping');
+    this.checkoutButton = this.cartFooter.getByTestId('checkout');
     this.pageFooter = new PageFooter(page);
   }
 

--- a/tests/cartPage.spec.ts
+++ b/tests/cartPage.spec.ts
@@ -29,6 +29,8 @@ test.describe('Cart page tests', () => {
         await expect(cartPage.cartItem).toHaveCount(0);
         await expect(cartPage.cartFooter).toBeVisible();
         await expect(cartPage.actionButton).toHaveCount(2);
+        await expect(cartPage.continueShoppingButton).toBeVisible();
+        await expect(cartPage.checkoutButton).toBeVisible();
         await expect(cartPage.pageFooter.footer).toBeVisible();
       });
 
@@ -74,13 +76,12 @@ test.describe('Cart page tests', () => {
       });
 
       test('Cursor is pointer for "Continue Shopping" and "Checkout" buttons', async () => {
-        for (let i = 0; i < (await cartPage.actionButton.count()); i++) {
-          await expect(cartPage.actionButton.nth(i)).toHaveCSS('cursor', 'pointer');
-        }
+        await expect(cartPage.continueShoppingButton).toHaveCSS('cursor', 'pointer');
+        await expect(cartPage.checkoutButton).toHaveCSS('cursor', 'pointer');
       });
 
       test('"Checkout" button is enabled even when cart is empty', async () => {
-        await expect(cartPage.actionButton.nth(1)).toBeEnabled();
+        await expect(cartPage.checkoutButton).toBeEnabled();
       });
 
       test.describe('Visual tests', () => {
@@ -97,12 +98,12 @@ test.describe('Cart page tests', () => {
 
     test.describe('Behavioural tests', () => {
       test('"Continue Shopping" button opens inventory page', async ({ page, baseURL }) => {
-        await cartPage.actionButton.nth(0).click();
+        await cartPage.continueShoppingButton.click();
         await expect(page).toHaveURL(`${baseURL}${URLS.inventoryPage}`);
       });
 
       test('"Checkout" button opens checkout page', async ({ page, baseURL }) => {
-        await cartPage.actionButton.nth(1).click();
+        await cartPage.checkoutButton.click();
         await expect(page).toHaveURL(`${baseURL}${URLS.checkoutInfoPage}`);
       });
     });


### PR DESCRIPTION
Add locators to the `CartPage` POM for the "Continue Shopping" and "Checkout" buttons rather than using `.nth()` to reference them indirectly. This makes some of the Cart Page test cases easier to understand.

There are test cases where it still makes sense to iterate over the action buttons as a whole so I have left those untouched. But certainly when interacting with the buttons it makes sense to reference them directly via their own locators.