### PR TITLE
Delete LoginPage font sizes const

### DIFF
--- a/pages/loginPage.ts
+++ b/pages/loginPage.ts
@@ -117,10 +117,3 @@ export const EXPECTED_TEXT = {
     lockedOutUser: 'Epic sadface: Sorry, this user has been locked out.',
   },
 };
-
-export const FONT_SIZES = {
-  button: '16px',
-  header: '16px',
-  standard: '14px',
-  title: '24px',
-};

--- a/tests/loginPage.spec.ts
+++ b/tests/loginPage.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { LoginPage, COLORS, FONT_SIZES, EXPECTED_TEXT } from '../pages/loginPage';
+import { LoginPage, COLORS, EXPECTED_TEXT } from '../pages/loginPage';
 import { URLS } from '../data/pages';
 import { getCookies } from '../helpers/utils';
 
@@ -50,34 +50,34 @@ test.describe('Login page tests', () => {
     test('Element styling', async () => {
       await expect(loginPage.loginContainer).toHaveCSS('background-color', COLORS.loginContainer.backgroundColor);
       await expect(loginPage.title).toHaveCSS('color', COLORS.titleTextColor);
-      await expect(loginPage.title).toHaveCSS('font-size', FONT_SIZES.title);
+      await expect(loginPage.title).toHaveCSS('font-size', '24px');
       await expect(loginPage.title).toHaveCSS('text-align', 'center');
       await expect(loginPage.usernameInput).toHaveAttribute('type', 'text');
       await expect(loginPage.usernameInput).toHaveCSS('background-color', COLORS.loginForm.backgroundColor);
       await expect(loginPage.usernameInput).toHaveCSS('border-bottom-color', COLORS.input.borderColor);
       await expect(loginPage.usernameInput).toHaveCSS('color', COLORS.input.textColor);
-      await expect(loginPage.usernameInput).toHaveCSS('font-size', FONT_SIZES.standard);
+      await expect(loginPage.usernameInput).toHaveCSS('font-size', '14px');
       await expect(loginPage.usernameInput).toHaveCSS('text-align', 'start');
       await expect(loginPage.passwordInput).toHaveAttribute('type', 'password');
       await expect(loginPage.passwordInput).toHaveCSS('background-color', COLORS.loginForm.backgroundColor);
       await expect(loginPage.passwordInput).toHaveCSS('border-bottom-color', COLORS.input.borderColor);
       await expect(loginPage.passwordInput).toHaveCSS('color', COLORS.input.textColor);
-      await expect(loginPage.passwordInput).toHaveCSS('font-size', FONT_SIZES.standard);
+      await expect(loginPage.passwordInput).toHaveCSS('font-size', '14px');
       await expect(loginPage.passwordInput).toHaveCSS('text-align', 'start');
       await expect(loginPage.loginButton).toContainClass('submit-button');
       await expect(loginPage.loginButton).toHaveCSS('background-color', COLORS.loginButton.backgroundColor);
       await expect(loginPage.loginButton).toHaveCSS('border', `4px solid ${COLORS.loginButton.borderColor}`);
       await expect(loginPage.loginButton).toHaveCSS('color', COLORS.loginButton.textColor);
-      await expect(loginPage.loginButton).toHaveCSS('font-size', FONT_SIZES.button);
+      await expect(loginPage.loginButton).toHaveCSS('font-size', '16px');
       await expect(loginPage.credentialsContainer).toHaveCSS(
         'background-color',
         COLORS.credentialsContainer.backgroundColor
       );
       await expect(loginPage.credentialsContainer).toHaveCSS('color', COLORS.credentialsContainer.textColor);
-      await expect(loginPage.credentialsContainer).toHaveCSS('font-size', FONT_SIZES.standard);
-      await expect(loginPage.usernamesHeader).toHaveCSS('font-size', FONT_SIZES.header);
+      await expect(loginPage.credentialsContainer).toHaveCSS('font-size', '14px');
+      await expect(loginPage.usernamesHeader).toHaveCSS('font-size', '16px');
       await expect(loginPage.usernamesHeader).toHaveCSS('font-weight', '700');
-      await expect(loginPage.passwordHeader).toHaveCSS('font-size', FONT_SIZES.header);
+      await expect(loginPage.passwordHeader).toHaveCSS('font-size', '16px');
       await expect(loginPage.passwordHeader).toHaveCSS('font-weight', '700');
     });
 


### PR DESCRIPTION
When I wrote the `LoginPage` POM I added a `FONT_SIZES` const object that declared the font size for various elements and used that const in the corresponding tests. I haven't done this for subsequent POMs I added to the test framework so wanted to make things consistent. 

When reviewing the test specs I decided it was easier to understand and maintain the tests that explicitly stated the expected font size rather than referencing a const object so to give me the consistency I wanted I have deleted the `FONT_SIZES` const object from the `LoginPage` POM and updated the tests to use an explicit font size instead.