### PR TITLE
Rework element styling tests

### DIFF
--- a/tests/cartPage.spec.ts
+++ b/tests/cartPage.spec.ts
@@ -44,34 +44,36 @@ test.describe('Cart page tests', () => {
       });
 
       test('Element styling', async ({ browserName }) => {
-        await expect(cartPage.subtitle).toHaveCSS('color', COLORS.textColor);
-        await expect(cartPage.subtitle).toHaveCSS('font-size', '18px');
-        await expect(cartPage.subtitle).toHaveCSS('font-weight', '500');
+        let element = cartPage.subtitle;
+        await expect(element).toHaveCSS('color', COLORS.textColor);
+        await expect(element).toHaveCSS('font-size', '18px');
+        await expect(element).toHaveCSS('font-weight', '500');
+
         await expect(cartPage.cartContentsContainer).toHaveCSS('background-color', COLORS.backgroundColor);
 
         await expect(cartPage.cartList).toHaveCSS('display', 'block');
+
         const headers = [cartPage.qtyHeader, cartPage.descHeader];
         for (let i = 0; i < headers.length; i++) {
-          await expect(headers[i]).toHaveCSS('color', COLORS.itemList.headerColor);
-          await expect(headers[i]).toHaveCSS('display', 'inline-block');
-          await expect(headers[i]).toHaveCSS('font-size', '16px');
-          await expect(headers[i]).toHaveCSS('font-weight', '500');
+          element = headers[i];
+          await expect(element).toHaveCSS('color', COLORS.itemList.headerColor);
+          await expect(element).toHaveCSS('display', 'inline-block');
+          await expect(element).toHaveCSS('font-size', '16px');
+          await expect(element).toHaveCSS('font-weight', '500');
         }
 
         await expect(cartPage.cartFooter).toHaveCSS('display', 'flex');
         for (let i = 0; i < (await cartPage.actionButton.count()); i++) {
+          element = cartPage.actionButton.nth(i);
           const expectedClass = i == 1 ? 'btn_action' : 'btn_secondary';
-          await expect(cartPage.actionButton.nth(i)).toContainClass(expectedClass);
-          await expect(cartPage.actionButton.nth(i)).toHaveCSS('background-color', COLORS.buttons[i].backgroundColor);
-          await expect(cartPage.actionButton.nth(i)).toHaveCSS('color', COLORS.buttons[i].textColor);
+          await expect(element).toContainClass(expectedClass);
+          await expect(element).toHaveCSS('background-color', COLORS.buttons[i].backgroundColor);
+          await expect(element).toHaveCSS('color', COLORS.buttons[i].textColor);
           const expectedBorderStyle = i === 1 ? (browserName === 'firefox' ? '0px' : '0px none') : '1px solid';
-          await expect(cartPage.actionButton.nth(i)).toHaveCSS(
-            'border',
-            `${expectedBorderStyle} ${COLORS.buttons[i].borderColor}`
-          );
-          await expect(cartPage.actionButton.nth(i)).toHaveCSS('border-radius', '4px');
-          await expect(cartPage.actionButton.nth(i)).toHaveCSS('font-size', '16px');
-          await expect(cartPage.actionButton.nth(i)).toHaveCSS('font-weight', '500');
+          await expect(element).toHaveCSS('border', `${expectedBorderStyle} ${COLORS.buttons[i].borderColor}`);
+          await expect(element).toHaveCSS('border-radius', '4px');
+          await expect(element).toHaveCSS('font-size', '16px');
+          await expect(element).toHaveCSS('font-weight', '500');
         }
       });
 

--- a/tests/checkoutInfoPage.spec.ts
+++ b/tests/checkoutInfoPage.spec.ts
@@ -54,16 +54,18 @@ test.describe('Checkout info page tests', () => {
     });
 
     test('Default element styling', async ({ browserName }) => {
-      await expect(checkoutInfoPage.subtitle).toHaveCSS('color', COLORS.subtitleColor);
-      await expect(checkoutInfoPage.subtitle).toHaveCSS('font-size', '18px');
-      await expect(checkoutInfoPage.subtitle).toHaveCSS('font-weight', '500');
+      let element = checkoutInfoPage.subtitle;
+      await expect(element).toHaveCSS('color', COLORS.subtitleColor);
+      await expect(element).toHaveCSS('font-size', '18px');
+      await expect(element).toHaveCSS('font-weight', '500');
 
-      await expect(checkoutInfoPage.checkoutInfoForm).toHaveCSS('border', `1px solid ${COLORS.borderColor}`);
-      await expect(checkoutInfoPage.checkoutInfoForm).toHaveCSS('border-radius', '8px');
-      await expect(checkoutInfoPage.checkoutInfoForm).toHaveCSS('padding', '40px 40px 0px');
+      element = checkoutInfoPage.checkoutInfoForm;
+      await expect(element).toHaveCSS('border', `1px solid ${COLORS.borderColor}`);
+      await expect(element).toHaveCSS('border-radius', '8px');
+      await expect(element).toHaveCSS('padding', '40px 40px 0px');
 
       for (let i = 0; i < (await checkoutInfoPage.formInput.count()); i++) {
-        const element = checkoutInfoPage.formInput.nth(i);
+        element = checkoutInfoPage.formInput.nth(i);
         await expect(element).not.toContainClass('error');
         await expect(element).toHaveCSS('border', '');
         await expect(element).toHaveCSS('border-bottom', `1px solid ${COLORS.input.borderColor}`);
@@ -73,38 +75,32 @@ test.describe('Checkout info page tests', () => {
         await expect(element).toHaveCSS('padding', '10px 0px');
       }
 
-      await expect(checkoutInfoPage.errorMessageContainer).not.toContainClass('error');
-      await expect(checkoutInfoPage.errorMessageContainer).toHaveCSS('background-color', COLORS.backgroundColor);
-      await expect(checkoutInfoPage.errorMessageContainer).toHaveCSS('display', 'flex');
-      await expect(checkoutInfoPage.errorMessageContainer).toHaveCSS('justify-content', 'center');
-      await expect(checkoutInfoPage.errorMessageContainer).toHaveCSS('margin-bottom', '5px');
-      await expect(checkoutInfoPage.errorMessageContainer).toHaveCSS('margin-top', '-10px');
-      await expect(checkoutInfoPage.errorMessageContainer).toHaveCSS('padding-left', '10px');
-      await expect(checkoutInfoPage.errorMessageContainer).toHaveCSS('padding-right', '10px');
-      await expect(checkoutInfoPage.errorMessageContainer).toHaveCSS('position', 'relative');
+      element = checkoutInfoPage.errorMessageContainer;
+      await expect(element).not.toContainClass('error');
+      await expect(element).toHaveCSS('background-color', COLORS.backgroundColor);
+      await expect(element).toHaveCSS('display', 'flex');
+      await expect(element).toHaveCSS('justify-content', 'center');
+      await expect(element).toHaveCSS('margin-bottom', '5px');
+      await expect(element).toHaveCSS('margin-top', '-10px');
+      await expect(element).toHaveCSS('padding-left', '10px');
+      await expect(element).toHaveCSS('padding-right', '10px');
+      await expect(element).toHaveCSS('position', 'relative');
 
-      await expect(checkoutInfoPage.checkoutButtonsContainer).toHaveCSS(
-        'border-top',
-        `1px solid ${COLORS.borderColor}`
-      );
-      await expect(checkoutInfoPage.checkoutButtonsContainer).toHaveCSS('display', 'flex');
+      element = checkoutInfoPage.checkoutButtonsContainer;
+      await expect(element).toHaveCSS('border-top', `1px solid ${COLORS.borderColor}`);
+      await expect(element).toHaveCSS('display', 'flex');
 
       for (let i = 0; i < (await checkoutInfoPage.actionButton.count()); i++) {
+        element = checkoutInfoPage.actionButton.nth(i);
         const expectedClass = i == 1 ? 'btn_action' : 'btn_secondary';
-        await expect(checkoutInfoPage.actionButton.nth(i)).toContainClass(expectedClass);
-        await expect(checkoutInfoPage.actionButton.nth(i)).toHaveCSS(
-          'background-color',
-          COLORS.buttons[i].backgroundColor
-        );
-        await expect(checkoutInfoPage.actionButton.nth(i)).toHaveCSS('color', COLORS.buttons[i].textColor);
+        await expect(element).toContainClass(expectedClass);
+        await expect(element).toHaveCSS('background-color', COLORS.buttons[i].backgroundColor);
+        await expect(element).toHaveCSS('color', COLORS.buttons[i].textColor);
         const expectedBorderStyle = i === 1 ? (browserName === 'firefox' ? '0px' : '0px none') : '1px solid';
-        await expect(checkoutInfoPage.actionButton.nth(i)).toHaveCSS(
-          'border',
-          `${expectedBorderStyle} ${COLORS.buttons[i].borderColor}`
-        );
-        await expect(checkoutInfoPage.actionButton.nth(i)).toHaveCSS('border-radius', '4px');
-        await expect(checkoutInfoPage.actionButton.nth(i)).toHaveCSS('font-size', '16px');
-        await expect(checkoutInfoPage.actionButton.nth(i)).toHaveCSS('font-weight', '500');
+        await expect(element).toHaveCSS('border', `${expectedBorderStyle} ${COLORS.buttons[i].borderColor}`);
+        await expect(element).toHaveCSS('border-radius', '4px');
+        await expect(element).toHaveCSS('font-size', '16px');
+        await expect(element).toHaveCSS('font-weight', '500');
       }
     });
 

--- a/tests/inventoryPage.spec.ts
+++ b/tests/inventoryPage.spec.ts
@@ -31,12 +31,15 @@ test.describe('Inventory page tests', () => {
     });
 
     test('Element styling', async () => {
-      await expect(inventoryPage.body).toHaveCSS('background-color', COLORS.backgroundColor);
-      await expect(inventoryPage.body).toHaveCSS('color', COLORS.textColor);
-      await expect(inventoryPage.body).toHaveCSS('font-size', '14px');
+      let element = inventoryPage.body;
+      await expect(element).toHaveCSS('background-color', COLORS.backgroundColor);
+      await expect(element).toHaveCSS('color', COLORS.textColor);
+      await expect(element).toHaveCSS('font-size', '14px');
 
-      await expect(inventoryPage.subtitle).toHaveCSS('font-size', '18px');
-      await expect(inventoryPage.subtitle).toHaveCSS('font-weight', '500');
+      element = inventoryPage.subtitle;
+      await expect(element).toHaveCSS('font-size', '18px');
+      await expect(element).toHaveCSS('font-weight', '500');
+
       await expect(inventoryPage.activeSortOption).toHaveCSS('text-align', 'center');
     });
 
@@ -64,19 +67,23 @@ test.describe('Inventory page tests', () => {
 
     test('Default product styling', async () => {
       for (let i = 0; i < NUM_PRODUCTS; i++) {
-        await expect(inventoryPage.inventoryItem.nth(i)).toHaveCSS('border', `1px solid ${COLORS.product.borderColor}`);
-        await expect(inventoryPage.inventoryItem.nth(i)).toHaveCSS('border-radius', '8px');
-        await expect(inventoryPage.inventoryItem.nth(i)).toHaveCSS('display', 'flex');
-        await expect(inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.title)).toHaveCSS(
-          'color',
-          COLORS.product.titleColor
-        );
-        await expect(inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.title)).toHaveCSS('font-size', '20px');
-        await expect(inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.title)).toHaveCSS('font-weight', '500');
-        await expect(inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.price)).toHaveCSS('font-size', '20px');
-        await expect(inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.price)).toHaveCSS('font-weight', '500');
-        await expect(inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.button)).toHaveCSS('font-size', '16px');
-        await expect(inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.button)).toHaveCSS('font-weight', '500');
+        let element = inventoryPage.inventoryItem.nth(i);
+        await expect(element).toHaveCSS('border', `1px solid ${COLORS.product.borderColor}`);
+        await expect(element).toHaveCSS('border-radius', '8px');
+        await expect(element).toHaveCSS('display', 'flex');
+
+        element = inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.title);
+        await expect(element).toHaveCSS('color', COLORS.product.titleColor);
+        await expect(element).toHaveCSS('font-size', '20px');
+        await expect(element).toHaveCSS('font-weight', '500');
+
+        element = inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.price);
+        await expect(element).toHaveCSS('font-size', '20px');
+        await expect(element).toHaveCSS('font-weight', '500');
+
+        element = inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.button);
+        await expect(element).toHaveCSS('font-size', '16px');
+        await expect(element).toHaveCSS('font-weight', '500');
       }
     });
 
@@ -124,28 +131,22 @@ test.describe('Inventory page tests', () => {
           await expect(inventoryPage.activeSortOption).toHaveText(testCase.sortBy);
 
           for (let i = 0; i < testCase.products.length; i++) {
-            await expect(inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.img)).toHaveAttribute(
-              'src',
-              testCase.products[i].imgSrc
-            );
-            await expect(inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.img)).toHaveAttribute(
-              'alt',
-              testCase.products[i].title
-            );
-            await expect(inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.title)).toHaveText(
-              testCase.products[i].title
-            );
-            await expect(inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.description)).toHaveText(
-              testCase.products[i].description
-            );
-            await expect(inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.price)).toHaveText(
-              `\$${testCase.products[i].price}`
-            );
+            let element = inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.img);
+            await expect(element).toHaveAttribute('src', testCase.products[i].imgSrc);
+            await expect(element).toHaveAttribute('alt', testCase.products[i].title);
 
-            await expect(inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.button)).toBeVisible();
-            await expect(inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.button)).toHaveText(
-              EXPECTED_TEXT.addToCartButton
-            );
+            element = inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.title);
+            await expect(element).toHaveText(testCase.products[i].title);
+
+            element = inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.description);
+            await expect(element).toHaveText(testCase.products[i].description);
+
+            element = inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.price);
+            await expect(element).toHaveText(`\$${testCase.products[i].price}`);
+
+            element = inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.button);
+            await expect(element).toBeVisible();
+            await expect(element).toHaveText(EXPECTED_TEXT.addToCartButton);
           }
         });
       });

--- a/tests/loginPage.spec.ts
+++ b/tests/loginPage.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { LoginPage, COLORS, EXPECTED_TEXT } from '../pages/loginPage';
 import { URLS } from '../data/pages';
-import { getCookies } from '../helpers/utils';
+import { getCookies, login } from '../helpers/utils';
 
 test.describe('Login page tests', () => {
   let loginPage: LoginPage;
@@ -48,37 +48,49 @@ test.describe('Login page tests', () => {
     });
 
     test('Element styling', async () => {
-      await expect(loginPage.loginContainer).toHaveCSS('background-color', COLORS.loginContainer.backgroundColor);
-      await expect(loginPage.title).toHaveCSS('color', COLORS.titleTextColor);
-      await expect(loginPage.title).toHaveCSS('font-size', '24px');
-      await expect(loginPage.title).toHaveCSS('text-align', 'center');
-      await expect(loginPage.usernameInput).toHaveAttribute('type', 'text');
-      await expect(loginPage.usernameInput).toHaveCSS('background-color', COLORS.loginForm.backgroundColor);
-      await expect(loginPage.usernameInput).toHaveCSS('border-bottom-color', COLORS.input.borderColor);
-      await expect(loginPage.usernameInput).toHaveCSS('color', COLORS.input.textColor);
-      await expect(loginPage.usernameInput).toHaveCSS('font-size', '14px');
-      await expect(loginPage.usernameInput).toHaveCSS('text-align', 'start');
-      await expect(loginPage.passwordInput).toHaveAttribute('type', 'password');
-      await expect(loginPage.passwordInput).toHaveCSS('background-color', COLORS.loginForm.backgroundColor);
-      await expect(loginPage.passwordInput).toHaveCSS('border-bottom-color', COLORS.input.borderColor);
-      await expect(loginPage.passwordInput).toHaveCSS('color', COLORS.input.textColor);
-      await expect(loginPage.passwordInput).toHaveCSS('font-size', '14px');
-      await expect(loginPage.passwordInput).toHaveCSS('text-align', 'start');
-      await expect(loginPage.loginButton).toContainClass('submit-button');
-      await expect(loginPage.loginButton).toHaveCSS('background-color', COLORS.loginButton.backgroundColor);
-      await expect(loginPage.loginButton).toHaveCSS('border', `4px solid ${COLORS.loginButton.borderColor}`);
-      await expect(loginPage.loginButton).toHaveCSS('color', COLORS.loginButton.textColor);
-      await expect(loginPage.loginButton).toHaveCSS('font-size', '16px');
-      await expect(loginPage.credentialsContainer).toHaveCSS(
-        'background-color',
-        COLORS.credentialsContainer.backgroundColor
-      );
-      await expect(loginPage.credentialsContainer).toHaveCSS('color', COLORS.credentialsContainer.textColor);
-      await expect(loginPage.credentialsContainer).toHaveCSS('font-size', '14px');
-      await expect(loginPage.usernamesHeader).toHaveCSS('font-size', '16px');
-      await expect(loginPage.usernamesHeader).toHaveCSS('font-weight', '700');
-      await expect(loginPage.passwordHeader).toHaveCSS('font-size', '16px');
-      await expect(loginPage.passwordHeader).toHaveCSS('font-weight', '700');
+      let element = loginPage.loginContainer;
+      await expect(element).toHaveCSS('background-color', COLORS.loginContainer.backgroundColor);
+
+      element = loginPage.title;
+      await expect(element).toHaveCSS('color', COLORS.titleTextColor);
+      await expect(element).toHaveCSS('font-size', '24px');
+      await expect(element).toHaveCSS('text-align', 'center');
+
+      element = loginPage.usernameInput;
+      await expect(element).toHaveAttribute('type', 'text');
+      await expect(element).toHaveCSS('background-color', COLORS.loginForm.backgroundColor);
+      await expect(element).toHaveCSS('border-bottom-color', COLORS.input.borderColor);
+      await expect(element).toHaveCSS('color', COLORS.input.textColor);
+      await expect(element).toHaveCSS('font-size', '14px');
+      await expect(element).toHaveCSS('text-align', 'start');
+
+      element = loginPage.passwordInput;
+      await expect(element).toHaveAttribute('type', 'password');
+      await expect(element).toHaveCSS('background-color', COLORS.loginForm.backgroundColor);
+      await expect(element).toHaveCSS('border-bottom-color', COLORS.input.borderColor);
+      await expect(element).toHaveCSS('color', COLORS.input.textColor);
+      await expect(element).toHaveCSS('font-size', '14px');
+      await expect(element).toHaveCSS('text-align', 'start');
+
+      element = loginPage.loginButton;
+      await expect(element).toContainClass('submit-button');
+      await expect(element).toHaveCSS('background-color', COLORS.loginButton.backgroundColor);
+      await expect(element).toHaveCSS('border', `4px solid ${COLORS.loginButton.borderColor}`);
+      await expect(element).toHaveCSS('color', COLORS.loginButton.textColor);
+      await expect(element).toHaveCSS('font-size', '16px');
+
+      element = loginPage.credentialsContainer;
+      await expect(element).toHaveCSS('background-color', COLORS.credentialsContainer.backgroundColor);
+      await expect(element).toHaveCSS('color', COLORS.credentialsContainer.textColor);
+      await expect(element).toHaveCSS('font-size', '14px');
+
+      element = loginPage.usernamesHeader;
+      await expect(element).toHaveCSS('font-size', '16px');
+      await expect(element).toHaveCSS('font-weight', '700');
+
+      element = loginPage.passwordHeader;
+      await expect(element).toHaveCSS('font-size', '16px');
+      await expect(element).toHaveCSS('font-weight', '700');
     });
 
     test.describe('Visual tests', () => {

--- a/tests/menu.spec.ts
+++ b/tests/menu.spec.ts
@@ -54,12 +54,13 @@ test.describe('Menu tests', () => {
       await pageHeader.menuButton.click();
       await expect(menu.menu).toHaveCSS('position', 'fixed');
       for (let i = 0; i < EXPECTED_TEXT.menuItems.length; i++) {
-        await expect(menu.menuItem.nth(i)).toHaveCSS('color', COLORS.textColor);
-        await expect(menu.menuItem.nth(i)).toHaveCSS('border-bottom', `1px solid ${COLORS.borderColor}`);
-        await expect(menu.menuItem.nth(i)).toHaveCSS('font-size', '16px');
+        let element = menu.menuItem.nth(i);
+        await expect(element).toHaveCSS('color', COLORS.textColor);
+        await expect(element).toHaveCSS('border-bottom', `1px solid ${COLORS.borderColor}`);
+        await expect(element).toHaveCSS('font-size', '16px');
 
-        await menu.menuItem.nth(i).hover();
-        await expect(menu.menuItem.nth(i)).toHaveCSS('color', COLORS.hoverColor);
+        await element.hover();
+        await expect(element).toHaveCSS('color', COLORS.hoverColor);
       }
     });
 

--- a/tests/pageFooter.spec.ts
+++ b/tests/pageFooter.spec.ts
@@ -35,10 +35,11 @@ test.describe('Page footer tests', () => {
       const numSocialMediaItems = await pageFooter.socialMediaItem.count();
       const regex = '^url\\("data:image\\/png;base64,[A-Za-z0-9+\\/=\\"\\)]*$';
       for (let i = 0; i < numSocialMediaItems; i++) {
+        let element = pageFooter.socialMediaLink.nth(i);
         // Social media items each have a different base64-encoded background image so verify against a regex
-        await expect(pageFooter.socialMediaItem.nth(i)).toHaveCSS('background-image', new RegExp(regex));
-        await expect(pageFooter.socialMediaLink.nth(i)).toHaveCSS('color', COLORS.socialLinkTextColor);
-        await expect(pageFooter.socialMediaLink.nth(i)).toHaveCSS('font-size', '0px');
+        await expect(element).toHaveCSS('background-image', new RegExp(regex));
+        await expect(element).toHaveCSS('color', COLORS.socialLinkTextColor);
+        await expect(element).toHaveCSS('font-size', '0px');
       }
       await expect(pageFooter.footerCopy).toHaveCSS('color', COLORS.textColor);
     });
@@ -60,9 +61,10 @@ test.describe('Page footer tests', () => {
 
   test('Social media links open relevant page in new tab', async () => {
     for (let i = 0; i < SOCIAL_LINKS.length; i++) {
-      await expect(pageFooter.socialMediaLink.nth(i)).toHaveAttribute('href', SOCIAL_LINKS[i]);
-      await expect(pageFooter.socialMediaLink.nth(i)).toHaveAttribute('target', '_blank');
-      await expect(pageFooter.socialMediaLink.nth(i)).toHaveAttribute('rel', 'noreferrer');
+      let element = pageFooter.socialMediaLink.nth(i);
+      await expect(element).toHaveAttribute('href', SOCIAL_LINKS[i]);
+      await expect(element).toHaveAttribute('target', '_blank');
+      await expect(element).toHaveAttribute('rel', 'noreferrer');
     }
   });
 });

--- a/tests/pageFooter.spec.ts
+++ b/tests/pageFooter.spec.ts
@@ -35,11 +35,10 @@ test.describe('Page footer tests', () => {
       const numSocialMediaItems = await pageFooter.socialMediaItem.count();
       const regex = '^url\\("data:image\\/png;base64,[A-Za-z0-9+\\/=\\"\\)]*$';
       for (let i = 0; i < numSocialMediaItems; i++) {
-        let element = pageFooter.socialMediaLink.nth(i);
         // Social media items each have a different base64-encoded background image so verify against a regex
-        await expect(element).toHaveCSS('background-image', new RegExp(regex));
-        await expect(element).toHaveCSS('color', COLORS.socialLinkTextColor);
-        await expect(element).toHaveCSS('font-size', '0px');
+        await expect(pageFooter.socialMediaItem.nth(i)).toHaveCSS('background-image', new RegExp(regex));
+        await expect(pageFooter.socialMediaLink.nth(i)).toHaveCSS('color', COLORS.socialLinkTextColor);
+        await expect(pageFooter.socialMediaLink.nth(i)).toHaveCSS('font-size', '0px');
       }
       await expect(pageFooter.footerCopy).toHaveCSS('color', COLORS.textColor);
     });

--- a/tests/pageHeader.spec.ts
+++ b/tests/pageHeader.spec.ts
@@ -34,24 +34,28 @@ test.describe('Page header tests', () => {
     });
 
     test('Element styling', async () => {
-      await expect(pageHeader.headerContainer).toHaveCSS('border-bottom', `1px solid ${COLORS.borderColor}`);
-      await expect(pageHeader.headerContainer).toHaveCSS('color', COLORS.textColor);
-      await expect(pageHeader.headerContainer).toHaveCSS('display', 'flex');
+      let element = pageHeader.headerContainer;
+      await expect(element).toHaveCSS('border-bottom', `1px solid ${COLORS.borderColor}`);
+      await expect(element).toHaveCSS('color', COLORS.textColor);
+      await expect(element).toHaveCSS('display', 'flex');
 
-      await expect(pageHeader.title).toHaveCSS('font-size', '24px');
-      await expect(pageHeader.title).toHaveCSS('text-align', 'center');
+      element = pageHeader.title;
+      await expect(element).toHaveCSS('font-size', '24px');
+      await expect(element).toHaveCSS('text-align', 'center');
 
+      element = pageHeader.menuButton;
       // Menu button is in the top-left
-      await expect(pageHeader.menuButton).toHaveCSS('position', 'absolute');
-      await expect(pageHeader.menuButton).toHaveCSS('left', '0px');
-      await expect(pageHeader.menuButton).toHaveCSS('top', '0px');
+      await expect(element).toHaveCSS('position', 'absolute');
+      await expect(element).toHaveCSS('left', '0px');
+      await expect(element).toHaveCSS('top', '0px');
 
+      element = pageHeader.shoppingCartContainer;
       // Shopping cart link is in the top-right (within a container)
-      await expect(pageHeader.shoppingCartContainer).toHaveCSS('position', 'absolute');
-      await expect(pageHeader.shoppingCartContainer).toHaveCSS('right', '20px');
-      await expect(pageHeader.shoppingCartContainer).toHaveCSS('top', '10px');
-      await expect(pageHeader.shoppingCartContainer).toHaveCSS('width', '40px');
-      await expect(pageHeader.shoppingCartContainer).toHaveCSS('height', '40px');
+      await expect(element).toHaveCSS('position', 'absolute');
+      await expect(element).toHaveCSS('right', '20px');
+      await expect(element).toHaveCSS('top', '10px');
+      await expect(element).toHaveCSS('width', '40px');
+      await expect(element).toHaveCSS('height', '40px');
     });
 
     // The cart in the main header shows a badge indicating the number of products in the cart (if not 0)

--- a/tests/productPage.spec.ts
+++ b/tests/productPage.spec.ts
@@ -36,28 +36,41 @@ test.describe('Product page tests', () => {
       });
 
       test('Element styling', async () => {
-        await expect(productPage.body).toHaveCSS('background-color', COLORS.backgroundColor);
-        await expect(productPage.body).toHaveCSS('color', COLORS.textColor);
-        await expect(productPage.body).toHaveCSS('font-size', '14px');
+        let element = productPage.body;
+        await expect(element).toHaveCSS('background-color', COLORS.backgroundColor);
+        await expect(element).toHaveCSS('color', COLORS.textColor);
+        await expect(element).toHaveCSS('font-size', '14px');
 
-        await expect(productPage.backButton).toHaveCSS('font-size', '16px');
-        await expect(productPage.backButton).toHaveCSS('font-weight', '500');
+        element = productPage.backButton;
+        await expect(element).toHaveCSS('font-size', '16px');
+        await expect(element).toHaveCSS('font-weight', '500');
 
-        await expect(productPage.inventoryItemContainer).toHaveCSS('background-color', COLORS.backgroundColor);
-        await expect(productPage.inventoryItem).toHaveCSS('border', `1px solid ${COLORS.product.borderColor}`);
-        await expect(productPage.inventoryItem).toHaveCSS('border-radius', '8px');
-        await expect(productPage.inventoryItem).toHaveCSS('color', COLORS.textColor);
-        await expect(productPage.inventoryItem).toHaveCSS('display', 'flex');
-        await expect(productPage.productName).toHaveCSS('font-size', '20px');
-        await expect(productPage.productName).toHaveCSS('font-weight', '500');
-        await expect(productPage.productDescription).toHaveCSS('font-size', '14px');
-        await expect(productPage.productPrice).toHaveCSS('font-size', '20px');
-        await expect(productPage.productPrice).toHaveCSS('font-weight', '500');
-        await expect(productPage.cartButton).toHaveCSS('border', `1px solid ${COLORS.textColor}`);
-        await expect(productPage.cartButton).toHaveCSS('border-radius', '4px');
-        await expect(productPage.cartButton).toHaveCSS('font-size', '16px');
-        await expect(productPage.cartButton).toHaveCSS('font-weight', '500');
-        await expect(productPage.cartButton).toHaveCSS('width', '160px');
+        element = productPage.inventoryItemContainer;
+        await expect(element).toHaveCSS('background-color', COLORS.backgroundColor);
+
+        element = productPage.inventoryItem;
+        await expect(element).toHaveCSS('border', `1px solid ${COLORS.product.borderColor}`);
+        await expect(element).toHaveCSS('border-radius', '8px');
+        await expect(element).toHaveCSS('color', COLORS.textColor);
+        await expect(element).toHaveCSS('display', 'flex');
+
+        element = productPage.productName;
+        await expect(element).toHaveCSS('font-size', '20px');
+        await expect(element).toHaveCSS('font-weight', '500');
+
+        element = productPage.productDescription;
+        await expect(element).toHaveCSS('font-size', '14px');
+
+        element = productPage.productPrice;
+        await expect(element).toHaveCSS('font-size', '20px');
+        await expect(element).toHaveCSS('font-weight', '500');
+
+        element = productPage.cartButton;
+        await expect(element).toHaveCSS('border', `1px solid ${COLORS.textColor}`);
+        await expect(element).toHaveCSS('border-radius', '4px');
+        await expect(element).toHaveCSS('font-size', '16px');
+        await expect(element).toHaveCSS('font-weight', '500');
+        await expect(element).toHaveCSS('width', '160px');
       });
 
       test('"Back to products" button style updates on hover', async () => {


### PR DESCRIPTION
The element styling tests for each page generally perform several assertions against each element. The tests were often written by duplicating the locator in each assertion which made some of them long and made the test harder to read. This PR splits these tests into smaller blocks each with a new `element` variable set to the locator for the element under test and the assertions updated accordingly. As a result the tests are much more readable and maintainable going forwards.