### PR TITLE
Refactor login function

### DIFF
--- a/helpers/utils.ts
+++ b/helpers/utils.ts
@@ -1,14 +1,9 @@
 import { BrowserContext, Cookie, expect, Locator, Page } from '@playwright/test';
-import { LoginPage } from '../pages/loginPage';
-import { URLS } from '../data/pages';
 
-export const login = async (page: Page, baseURL: string, username: string): Promise<void> => {
-  const loginPage = new LoginPage(page);
-  await page.goto(URLS.loginPage);
-  await loginPage.usernameInput.fill(username);
-  await loginPage.passwordInput.fill('secret_sauce');
-  await loginPage.loginButton.click();
-  await expect(page).toHaveURL(`${baseURL}${URLS.inventoryPage}`);
+export const login = async (context: BrowserContext, baseUrl: string, username: string): Promise<void> => {
+  // Login by setting a cookie rather than by entering user credentials on the login page
+  const COOKIE = { name: 'session-username', value: username, url: baseUrl };
+  await context.addCookies([COOKIE]);
 };
 
 export const getCartContentsFromLocalStorage = async (context: BrowserContext): Promise<Record<string, string>> => {

--- a/tests/cartList.spec.ts
+++ b/tests/cartList.spec.ts
@@ -7,18 +7,15 @@ import { PRODUCT_INFO } from '../data/products';
 test.describe('Cart list tests', () => {
   let cartList: CartList;
 
-  test.beforeEach(async ({ page, baseURL }) => {
+  test.beforeEach(async ({ page, context, baseURL }) => {
     cartList = new CartList(page);
-    await login(page, baseURL!, 'standard_user');
+    await login(context, baseURL!, 'standard_user');
+    // We can test the cart list on any page that uses it - namely the cart page and checkout overview page
+    // but the cart page is the simplest so open that
+    await page.goto(URLS.cartPage);
   });
 
   test.describe('Empty cart', () => {
-    // We can test the cart list on any page that uses it - namely the cart page and checkout overview page
-    // but the cart page is the simplest so open that
-    test.beforeEach(async ({ page }) => {
-      await page.goto(URLS.cartPage);
-    });
-
     test.describe('Appearance tests', () => {
       test('Default element visibility', async () => {
         await expect(cartList.cartList).toBeVisible();

--- a/tests/cartPage.spec.ts
+++ b/tests/cartPage.spec.ts
@@ -7,17 +7,14 @@ import { PRODUCT_INFO } from '../data/products';
 test.describe('Cart page tests', () => {
   let cartPage: CartPage;
 
-  test.beforeEach(async ({ page, baseURL }) => {
+  test.beforeEach(async ({ page, context, baseURL }) => {
     cartPage = new CartPage(page);
-    await login(page, baseURL!, 'standard_user');
+    await login(context, baseURL!, 'standard_user');
+    await page.goto(URLS.cartPage);
   });
 
+  // Common cart elements can be tested with an empty cart
   test.describe('Empty cart', () => {
-    test.beforeEach(async ({ page }) => {
-      await page.goto(URLS.cartPage);
-    });
-
-    // Common cart elements can be tested with an empty cart
     test.describe('Appearance tests', () => {
       test('Default element visibility', async () => {
         await expect(cartPage.pageHeader.primaryHeader).toBeVisible();

--- a/tests/checkoutCompletePage.spec.ts
+++ b/tests/checkoutCompletePage.spec.ts
@@ -8,9 +8,9 @@ test.describe('Checkout complete page tests', () => {
 
   // The checkout complete page doesn't change whether we purchased items or not so
   // we can proceed with an empty order and navigate directly to the page under test
-  test.beforeEach(async ({ page, baseURL }) => {
+  test.beforeEach(async ({ page, context, baseURL }) => {
     checkoutCompletePage = new CheckoutCompletePage(page);
-    await login(page, baseURL!, 'standard_user');
+    await login(context, baseURL!, 'standard_user');
     await page.goto(URLS.checkoutCompletePage);
   });
 

--- a/tests/checkoutInfoPage.spec.ts
+++ b/tests/checkoutInfoPage.spec.ts
@@ -8,9 +8,9 @@ test.describe('Checkout info page tests', () => {
 
   // The checkout info page doesn't change whether the cart contains items or not so
   // we can proceed with an empty cart and navigate directly to the page under test
-  test.beforeEach(async ({ page, baseURL }) => {
+  test.beforeEach(async ({ page, context, baseURL }) => {
     checkoutInfoPage = new CheckoutInfoPage(page);
-    await login(page, baseURL!, 'standard_user');
+    await login(context, baseURL!, 'standard_user');
     await page.goto(URLS.checkoutInfoPage);
   });
 

--- a/tests/checkoutOverviewPage.spec.ts
+++ b/tests/checkoutOverviewPage.spec.ts
@@ -8,17 +8,14 @@ import { PRODUCT_ELEMENTS } from '../pages/components/cartList';
 test.describe('Checkout overview page tests', () => {
   let checkoutOverviewPage: CheckoutOverviewPage;
 
-  test.beforeEach(async ({ page, baseURL }) => {
+  test.beforeEach(async ({ page, context, baseURL }) => {
     checkoutOverviewPage = new CheckoutOverviewPage(page);
-    await login(page, baseURL!, 'standard_user');
+    await login(context, baseURL!, 'standard_user');
+    await page.goto(URLS.checkoutOverviewPage);
   });
 
+  // Common cart elements can be tested without purchasing anything
   test.describe('No items purchased', () => {
-    test.beforeEach(async ({ page }) => {
-      await page.goto(URLS.checkoutOverviewPage);
-    });
-
-    // Common cart elements can be tested without purchasing anything
     test.describe('Appearance tests', () => {
       test('Default element visibility', async () => {
         await expect(checkoutOverviewPage.pageHeader.primaryHeader).toBeVisible();

--- a/tests/inventoryPage.spec.ts
+++ b/tests/inventoryPage.spec.ts
@@ -10,9 +10,10 @@ let inventoryPage: InventoryPage;
 let cartContents: Record<string, string>;
 
 test.describe('Standard User', () => {
-  test.beforeEach(async ({ page, baseURL }) => {
+  test.beforeEach(async ({ page, context, baseURL }) => {
     inventoryPage = new InventoryPage(page);
-    await login(page, baseURL!, 'standard_user');
+    await login(context, baseURL!, 'standard_user');
+    await page.goto(URLS.inventoryPage);
   });
 
   test.describe('Appearance tests', () => {
@@ -279,9 +280,10 @@ test.describe('Standard User', () => {
 test.describe('Problem User', () => {
   const PURCHASABLE_PRODUCTS = ['Backpack', 'Bike Light', 'Onesie'];
 
-  test.beforeEach(async ({ page, baseURL }) => {
+  test.beforeEach(async ({ page, context, baseURL }) => {
     inventoryPage = new InventoryPage(page);
-    await login(page, baseURL!, 'problem_user');
+    await login(context, baseURL!, 'problem_user');
+    await page.goto(URLS.inventoryPage);
   });
 
   test.describe('Appearance tests', () => {

--- a/tests/menu.spec.ts
+++ b/tests/menu.spec.ts
@@ -14,8 +14,9 @@ test.describe('Menu tests', () => {
   let menu: Menu;
   const numMenuItems = EXPECTED_TEXT.menuItems.length;
 
-  test.beforeEach(async ({ page, baseURL }) => {
-    await login(page, baseURL!, 'standard_user');
+  test.beforeEach(async ({ page, context, baseURL }) => {
+    await login(context, baseURL!, 'standard_user');
+    await page.goto(URLS.inventoryPage);
     pageHeader = new PageHeader(page);
     menu = new Menu(page);
   });

--- a/tests/pageFooter.spec.ts
+++ b/tests/pageFooter.spec.ts
@@ -3,6 +3,7 @@ import { COLORS, EXPECTED_TEXT, PageFooter, SOCIAL_LINKS } from '../pages/compon
 import { InventoryPage, PRODUCT_ELEMENTS } from '../pages/inventoryPage';
 import { PRODUCT_INFO } from '../data/products';
 import { login } from '../helpers/utils';
+import { URLS } from '../data/pages';
 
 // This spec makes a not unreasonable assumption that the footer displayed at the bottom of all pages
 // expect the login page is always the same. As such, the main assertions are performed against a single
@@ -11,8 +12,9 @@ import { login } from '../helpers/utils';
 test.describe('Page footer tests', () => {
   let pageFooter: PageFooter;
 
-  test.beforeEach(async ({ page, baseURL }) => {
-    await login(page, baseURL!, 'standard_user');
+  test.beforeEach(async ({ page, context, baseURL }) => {
+    await login(context, baseURL!, 'standard_user');
+    await page.goto(URLS.inventoryPage);
     pageFooter = new PageFooter(page);
   });
 

--- a/tests/pageHeader.spec.ts
+++ b/tests/pageHeader.spec.ts
@@ -13,8 +13,9 @@ import { URLS } from '../data/pages';
 test.describe('Page header tests', () => {
   let pageHeader: PageHeader;
 
-  test.beforeEach(async ({ page, baseURL }) => {
-    await login(page, baseURL!, 'standard_user');
+  test.beforeEach(async ({ page, context, baseURL }) => {
+    await login(context, baseURL!, 'standard_user');
+    await page.goto(URLS.inventoryPage);
     pageHeader = new PageHeader(page);
   });
 

--- a/tests/productPage.spec.ts
+++ b/tests/productPage.spec.ts
@@ -7,9 +7,9 @@ import { URLS } from '../data/pages';
 test.describe('Product page tests', () => {
   let productPage: ProductPage;
 
-  test.beforeEach(async ({ page, baseURL }) => {
+  test.beforeEach(async ({ page, context, baseURL }) => {
     productPage = new ProductPage(page);
-    await login(page, baseURL!, 'standard_user');
+    await login(context, baseURL!, 'standard_user');
   });
 
   test.describe('Common page elements', async () => {


### PR DESCRIPTION
The `login` function now logs the user in via a cookie rather than entering credentials on the form on the login page. This has the advantage of being faster but also means we can set the cookie then navigate directly to the relevant page for that test rather than logging in via the UI, being directed to the inventory page and then having to navigate onwards from there. Removing this additional redirect from the login flow improves performance and means we can take advantage of Playwright managing page loads, which is essential for tests that are to come for other users (where assets don't necessarily load immediately)