### PR TITLE
Extend product data with restrictedPurchase boolean

### DIFF
--- a/data/products.ts
+++ b/data/products.ts
@@ -1,4 +1,14 @@
-export const PRODUCT_INFO = [
+type Product = {
+  id: number;
+  title: string;
+  imgSrc: string;
+  description: string;
+  price: number;
+  shortName: string;
+  restrictedPurchase: boolean;
+};
+
+export const PRODUCT_INFO: Product[] = [
   {
     id: 4,
     title: 'Sauce Labs Backpack',
@@ -7,6 +17,7 @@ export const PRODUCT_INFO = [
       'carry.allTheThings() with the sleek, streamlined Sly Pack that melds uncompromising style with unequaled laptop and tablet protection.',
     price: 29.99,
     shortName: 'Backpack',
+    restrictedPurchase: false,
   },
   {
     id: 0,
@@ -16,6 +27,7 @@ export const PRODUCT_INFO = [
       "A red light isn't the desired state in testing but it sure helps when riding your bike at night. Water-resistant with 3 lighting modes, 1 AAA battery included.",
     price: 9.99,
     shortName: 'Bike Light',
+    restrictedPurchase: false,
   },
   {
     id: 1,
@@ -25,6 +37,7 @@ export const PRODUCT_INFO = [
       'Get your testing superhero on with the Sauce Labs bolt T-shirt. From American Apparel, 100% ringspun combed cotton, heather gray with red bolt.',
     price: 15.99,
     shortName: 'Bolt T-Shirt',
+    restrictedPurchase: true,
   },
   {
     id: 5,
@@ -34,6 +47,7 @@ export const PRODUCT_INFO = [
       "It's not every day that you come across a midweight quarter-zip fleece jacket capable of handling everything from a relaxing day outdoors to a busy day at the office.",
     price: 49.99,
     shortName: 'Fleece Jacket',
+    restrictedPurchase: true,
   },
   {
     id: 2,
@@ -43,6 +57,7 @@ export const PRODUCT_INFO = [
       "Rib snap infant onesie for the junior automation engineer in development. Reinforced 3-snap bottom closure, two-needle hemmed sleeved and bottom won't unravel.",
     price: 7.99,
     shortName: 'Onesie',
+    restrictedPurchase: false,
   },
   {
     id: 3,
@@ -52,5 +67,6 @@ export const PRODUCT_INFO = [
       'This classic Sauce Labs t-shirt is perfect to wear when cozying up to your keyboard to automate a few tests. Super-soft and comfy ringspun combed cotton.',
     price: 15.99,
     shortName: 'Red T-Shirt',
+    restrictedPurchase: true,
   },
 ];

--- a/tests/inventoryPage.spec.ts
+++ b/tests/inventoryPage.spec.ts
@@ -376,7 +376,8 @@ test.describe('Product tests', () => {
 
   [USERS.problem, USERS.error].forEach((user) => {
     test.describe(user.description, () => {
-      const PURCHASABLE_PRODUCTS = ['Backpack', 'Bike Light', 'Onesie'];
+      const PURCHASABLE_PRODUCTS = PRODUCT_INFO.filter((product) => !product.restrictedPurchase);
+
       test.beforeEach(async ({ page, context, baseURL }) => {
         await login(context, baseURL!, user.username);
         await page.goto(URLS.inventoryPage);
@@ -388,7 +389,7 @@ test.describe('Product tests', () => {
           await setCartContentsInLocalStorage(page, [], URLS.inventoryPage);
 
           await inventoryPage.getProductElement(i, PRODUCT_ELEMENTS.button).click();
-          if (PURCHASABLE_PRODUCTS.includes(PRODUCT_INFO[i].shortName)) {
+          if (PURCHASABLE_PRODUCTS.includes(PRODUCT_INFO[i])) {
             await expect(inventoryPage.pageHeader.shoppingCartBadge).toBeVisible();
             await expect(inventoryPage.pageHeader.shoppingCartBadge).toHaveText('1');
             await inventoryPage.verifyCartButtonStyle(i, 'remove');
@@ -413,7 +414,7 @@ test.describe('Product tests', () => {
           await setCartContentsInLocalStorage(page, [], URLS.inventoryPage);
 
           // Add product to cart
-          productIndex = PRODUCT_INFO.findIndex((prod) => prod.shortName === PURCHASABLE_PRODUCTS[i]);
+          productIndex = PRODUCT_INFO.findIndex((prod) => prod === PURCHASABLE_PRODUCTS[i]);
           await inventoryPage.getProductElement(productIndex, PRODUCT_ELEMENTS.button).click();
           await expect(inventoryPage.pageHeader.shoppingCartBadge).toBeVisible();
           await expect(inventoryPage.pageHeader.shoppingCartBadge).toHaveText('1');


### PR DESCRIPTION
Some of the available products cannot be purchased by `problem_user` and `error_user` - or at least they cannot be added to the cart in the usual way (it might be possible to force them into the cart by editing the local storage) i.e. they are restricted purchases. I have updated the `PRODUCT_INFO` array with an additional boolean flag on each product indicating whether it is restricted or not. I have also added a `Product` type and typed the `PRODUCT_INFO` array accordingly. The existing inventoty page tests have then been updated to replace the hardcoded `PURCHASABLE_PRODUCTS` array with a filtered version of the `PRODUCT_INFO` array using the new `restrictedPurchase` boolean flag.