### PR TITLE
Extend page footer tests to all users

### DIFF
--- a/tests/pageFooter.spec.ts
+++ b/tests/pageFooter.spec.ts
@@ -1,51 +1,64 @@
 import { test, expect } from '@playwright/test';
 import { COLORS, EXPECTED_TEXT, PageFooter, SOCIAL_LINKS } from '../pages/components/pageFooter';
-import { InventoryPage, PRODUCT_ELEMENTS } from '../pages/inventoryPage';
 import { PRODUCT_INFO } from '../data/products';
 import { login } from '../helpers/utils';
 import { URLS } from '../data/pages';
+import { USERS } from '../data/users';
+
+let pageFooter: PageFooter;
+
+test.beforeEach(async ({ page }) => {
+  pageFooter = new PageFooter(page);
+});
 
 // This spec makes a not unreasonable assumption that the footer displayed at the bottom of all pages
 // expect the login page is always the same. As such, the main assertions are performed against a single
 // page (the inventory page) with visual testing used to validate the assumption across other pages
 
-test.describe('Page footer tests', () => {
-  let pageFooter: PageFooter;
+test.describe('Appearance tests', () => {
+  [USERS.standard, USERS.problem, USERS.error, USERS.visual, USERS.performanceGlitch].forEach((user) => {
+    test.describe(user.description, () => {
+      test.beforeEach(async ({ page, context, baseURL }) => {
+        await login(context, baseURL!, user.username);
+        await page.goto(URLS.inventoryPage);
+      });
 
-  test.beforeEach(async ({ page, context, baseURL }) => {
-    await login(context, baseURL!, 'standard_user');
-    await page.goto(URLS.inventoryPage);
-    pageFooter = new PageFooter(page);
+      test('Default element visibility', async () => {
+        await expect(pageFooter.footer).toBeVisible();
+        await expect(pageFooter.socialMediaItem).toHaveCount(EXPECTED_TEXT.socialMedia.length);
+        await expect(pageFooter.footerCopy).toBeVisible();
+      });
+
+      test('Text content of elements', async () => {
+        for (let i = 0; i < EXPECTED_TEXT.socialMedia.length; i++) {
+          await expect(pageFooter.socialMediaItem.nth(i)).toHaveText(EXPECTED_TEXT.socialMedia[i]);
+        }
+        await expect(pageFooter.footerCopy).toHaveText(EXPECTED_TEXT.copy);
+      });
+
+      test('Element styling', async () => {
+        await expect(pageFooter.footer).toHaveCSS('background-color', COLORS.backgroundColor);
+        const numSocialMediaItems = await pageFooter.socialMediaItem.count();
+        const regex = '^url\\("data:image\\/png;base64,[A-Za-z0-9+\\/=\\"\\)]*$';
+        for (let i = 0; i < numSocialMediaItems; i++) {
+          // Social media items each have a different base64-encoded background image so verify against a regex
+          await expect(pageFooter.socialMediaItem.nth(i)).toHaveCSS('background-image', new RegExp(regex));
+          await expect(pageFooter.socialMediaLink.nth(i)).toHaveCSS('color', COLORS.socialLinkTextColor);
+          await expect(pageFooter.socialMediaLink.nth(i)).toHaveCSS('font-size', '0px');
+        }
+        await expect(pageFooter.footerCopy).toHaveCSS('color', COLORS.textColor);
+      });
+    });
   });
+});
 
-  test.describe('Appearance tests', () => {
-    test('Default element visibility', async () => {
-      await expect(pageFooter.footer).toBeVisible();
-      await expect(pageFooter.socialMediaItem).toHaveCount(EXPECTED_TEXT.socialMedia.length);
-      await expect(pageFooter.footerCopy).toBeVisible();
-    });
+test.describe('Visual tests', () => {
+  [USERS.standard, USERS.problem, USERS.error, USERS.visual, USERS.performanceGlitch].forEach((user) => {
+    test.describe(user.description, () => {
+      test.beforeEach(async ({ context, baseURL }) => {
+        await login(context, baseURL!, user.username);
+      });
 
-    test('Text content of elements', async () => {
-      for (let i = 0; i < EXPECTED_TEXT.socialMedia.length; i++) {
-        await expect(pageFooter.socialMediaItem.nth(i)).toHaveText(EXPECTED_TEXT.socialMedia[i]);
-      }
-      await expect(pageFooter.footerCopy).toHaveText(EXPECTED_TEXT.copy);
-    });
-
-    test('Element styling', async () => {
-      await expect(pageFooter.footer).toHaveCSS('background-color', COLORS.backgroundColor);
-      const numSocialMediaItems = await pageFooter.socialMediaItem.count();
-      const regex = '^url\\("data:image\\/png;base64,[A-Za-z0-9+\\/=\\"\\)]*$';
-      for (let i = 0; i < numSocialMediaItems; i++) {
-        // Social media items each have a different base64-encoded background image so verify against a regex
-        await expect(pageFooter.socialMediaItem.nth(i)).toHaveCSS('background-image', new RegExp(regex));
-        await expect(pageFooter.socialMediaLink.nth(i)).toHaveCSS('color', COLORS.socialLinkTextColor);
-        await expect(pageFooter.socialMediaLink.nth(i)).toHaveCSS('font-size', '0px');
-      }
-      await expect(pageFooter.footerCopy).toHaveCSS('color', COLORS.textColor);
-    });
-
-    test.describe('Visual tests', () => {
       // All pages should have the same footer
       // However, the checkout complete page footer is a slightly different size so is omitted from this visual testing
       const PAGES = [
@@ -70,13 +83,24 @@ test.describe('Page footer tests', () => {
       });
     });
   });
+});
 
-  test('Social media links open relevant page in new tab', async () => {
-    for (let i = 0; i < SOCIAL_LINKS.length; i++) {
-      let element = pageFooter.socialMediaLink.nth(i);
-      await expect(element).toHaveAttribute('href', SOCIAL_LINKS[i]);
-      await expect(element).toHaveAttribute('target', '_blank');
-      await expect(element).toHaveAttribute('rel', 'noreferrer');
-    }
+test.describe('Behavioural tests', () => {
+  [USERS.standard, USERS.problem, USERS.error, USERS.visual, USERS.performanceGlitch].forEach((user) => {
+    test.describe(user.description, () => {
+      test.beforeEach(async ({ page, context, baseURL }) => {
+        await login(context, baseURL!, user.username);
+        await page.goto(URLS.inventoryPage);
+      });
+
+      test('Social media links open relevant page in new tab', async () => {
+        for (let i = 0; i < SOCIAL_LINKS.length; i++) {
+          let element = pageFooter.socialMediaLink.nth(i);
+          await expect(element).toHaveAttribute('href', SOCIAL_LINKS[i]);
+          await expect(element).toHaveAttribute('target', '_blank');
+          await expect(element).toHaveAttribute('rel', 'noreferrer');
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
A nice simple one this time - extending the `pageFooter.spec.ts` tests to include all users, not just `standard_user`. The appearance and behaviour of the footer is the same for all users so this was a simple restructure along the same lines as the recent `inventoryPage.spec.ts` restructure to make it easier to run the tests as different users.