### PR TITLE
Compare users directly

### DIFF
--- a/tests/inventoryPage.spec.ts
+++ b/tests/inventoryPage.spec.ts
@@ -114,8 +114,8 @@ test.describe('Visual tests', () => {
         // mask the parent element instead. This does mean we're not visually testing the "Add to cart"
         // button for visual_user but we can live with that
         const MASKED_ELEMENTS =
-          user.description === 'Visual User' ? [inventoryPage.inventoryItem.locator(PRODUCT_ELEMENTS.pricebar)] : [];
-        await expect(inventoryPage.inventoryContainer).toHaveScreenshot(user.imgFilename, {
+          user === USERS.visual ? [inventoryPage.inventoryItem.locator(PRODUCT_ELEMENTS.pricebar)] : [];
+        await expect(inventoryPage.inventoryContainer).toHaveScreenshot(user.imgFilename!, {
           mask: MASKED_ELEMENTS,
         });
       });

--- a/tests/menu.spec.ts
+++ b/tests/menu.spec.ts
@@ -138,7 +138,7 @@ test.describe('Behavioural tests', () => {
 
       test('"About" menu link opens Sauce Labs webpage in current tab', async ({ page }) => {
         // The "About" link opens a 404 error page for the problem user
-        const EXPECTED_URL = user.description === 'Problem User' ? LINKS.error : LINKS.about;
+        const EXPECTED_URL = user === USERS.problem ? LINKS.error : LINKS.about;
         await menu.menuItem.filter({ hasText: EXPECTED_TEXT.menuItems[1] }).click();
         await expect(page).toHaveURL(EXPECTED_URL);
       });

--- a/tests/pageHeader.spec.ts
+++ b/tests/pageHeader.spec.ts
@@ -59,7 +59,7 @@ test.describe('Appearance tests', () => {
         // Shopping cart link is in the top-right (within a container)
         const VISUAL_FAILURE_CLASS = 'visual_failure';
         await expect(element).toHaveCSS('position', 'absolute');
-        if (user.description === 'Visual User') {
+        if (user === USERS.visual) {
           // The cart icon is misaligned for the Visual User account
           await expect(element).toContainClass(VISUAL_FAILURE_CLASS);
           await expect(element).toHaveCSS('right', '205px');
@@ -78,7 +78,7 @@ test.describe('Appearance tests', () => {
       // able to test the badge appearance in this spec we "force" products into the cart via local storage
       // rather than using the standard UI interactions
       test('Shopping cart badge appearance', async ({ page }) => {
-        if (user.description === 'Performance Glitch User') test.setTimeout(60_000);
+        if (user === USERS.performanceGlitch) test.setTimeout(60_000);
         let productIds: number[] = [];
         for (let i = 0; i < PRODUCT_INFO.length; i++) {
           productIds.push(i);


### PR DESCRIPTION
A small change here, comparing users directly by object rather than just a single property (description) when conditionally varianting assertions.