### PR TITLE
Config changes

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps ${{matrix.browser}}
       - name: Run Playwright tests
-        run: npx playwright test --project=${{matrix.browser}}
+        run: npm run test:${{matrix.browser}}
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps ${{matrix.browser}}
       - name: Run Playwright visual tests (only)
-        run: npx playwright test --project=${{matrix.browser}} --grep="visual tests"
+        run: npm run test:visual -- --project=${{matrix.browser}}
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/package.json
+++ b/package.json
@@ -1,10 +1,20 @@
 {
+  "author": "Mat Hare",
   "devDependencies": {
     "@playwright/test": "^1.56.1",
-    "@types/node": "^24.9.2"
-  },
-  "scripts": {},
-  "dependencies": {
+    "@types/node": "^24.9.2",
     "dotenv": "^17.2.3"
+  },
+  "scripts": {
+    "test": "npx playwright test",
+    "test:chromium": "npx playwright test --project=chromium",
+    "test:firefox": "npx playwright test --project=firefox",
+    "test:webkit": "npx playwright test --project=webkit",
+    "test:visual": "npx playwright test --grep=\"visual tests\"",
+    "test:standardUser": "npx playwright test --grep=\"standard user\"",
+    "test:problemUser": "npx playwright test --grep=\"problem user\"",
+    "test:errorUser": "npx playwright test --grep=\"error user\"",
+    "test:visualUser": "npx playwright test --grep=\"visual user\"",
+    "test:performanceUser": "npx playwright test --grep=\"performance glitch user\""
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,74 +8,31 @@ import dotenv from 'dotenv';
 import path from 'path';
 dotenv.config({ path: path.resolve(__dirname, '.env') });
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
 export default defineConfig({
   testDir: './tests',
-  /* Run tests in files in parallel */
   fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
+  retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  reporter: process.env.CI ? 'list' : [['html', { open: 'never' }]],
   use: {
-    /* Base URL to use in actions like `await page.goto('')`. */
     baseURL: 'https://www.saucedemo.com',
     testIdAttribute: 'data-test',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
   },
   snapshotPathTemplate: 'snapshots/{platform}/{projectName}/{testFilePath}/{arg}{ext}',
-
-  /* Configure projects for major browsers */
   projects: [
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
-
     {
       name: 'firefox',
       use: { ...devices['Desktop Firefox'] },
     },
-
     {
       name: 'webkit',
       use: { ...devices['Desktop Safari'] },
     },
-
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: { ...devices['iPhone 12'] },
-    // },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
   ],
-
-  /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://localhost:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
 });


### PR DESCRIPTION
Having completed the extension of the test suite to all users the final (or at least final planned) thing to be done for this project is to tweak some of the config/setup which has been as default since the start.

I have moved a dependency to be a dev dependency (as it should always have been) in the `package.json` and added a number of scripts to help with running the tests, including scripts to run the tests specific to each user, running tests on a specific browser type and also a script to run just the visual tests. These scripts have then been incorporated into the CI workflows, replacing the existing commands there.

I have also tweaked the Playwright config a little. I have removed the explanatory comments added when the default file was created to make it more readable. I have also updated the reporter used in CI (from dot to list) and changed the setting on the HTML reporter to never open the report as I found that annoying. I have also reduced the number of retries on CI from 2 to 1.